### PR TITLE
4WeekFix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,12 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' // 타임리프에서 layout.html 사용하려고
+
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,26 @@
 # 할일
 
+- [x] 내가 받은 호감 리스트
+  - [x] 성별 필터링
+  - [x] 호감사유 필터링
+    - [x] 원활한 테스트를 위해서 인스타 사용자 user4 가 다수의 호감표시를 받도록 NotProd 변경
+    - [x] NotProd 변경에 따른 테스트케이스 수정
+  - [x] 정렬
+    - [x] 최신순
+      - 애초에 최신순으로 정렬되어 있었음
+      - 그래서 딱히 할게 없음
+    - [x] 날짜순
+      - id DESC
+    - [x] 인기많은순
+      - likeCount DESC, id DESC
+      - 이 작업을 위해 NotProd 에서 호감표시건을 더 만듬
+    - [x] 인기적은순
+      - likeCount ASC, id DESC
+    - [x] 성별순
+      - gender DESC, id DESC
+    - [x] 호감사유순
+      - gender ASC, id DESC
+    - [x] 테스트케이스
 - [x] 알림
   - [x] 호감표시할 때 알림생성
   - [x] 호감사유변경할 때 알림생성

--- a/src/main/generated/com/ll/gramgram/base/baseEntity/QBaseEntity.java
+++ b/src/main/generated/com/ll/gramgram/base/baseEntity/QBaseEntity.java
@@ -1,0 +1,41 @@
+package com.ll.gramgram.base.baseEntity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1702204240L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createDate = createDateTime("createDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = createDateTime("modifyDate", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMember.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMember.java
@@ -1,0 +1,96 @@
+package com.ll.gramgram.boundedContext.instaMember.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInstaMember is a Querydsl query type for InstaMember
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QInstaMember extends EntityPathBase<InstaMember> {
+
+    private static final long serialVersionUID = -53334208L;
+
+    public static final QInstaMember instaMember = new QInstaMember("instaMember");
+
+    public final QInstaMemberBase _super = new QInstaMemberBase(this);
+
+    public final StringPath accessToken = createString("accessToken");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final ListPath<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson> fromLikeablePeople = this.<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson>createList("fromLikeablePeople", com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson.class, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.class, PathInits.DIRECT2);
+
+    //inherited
+    public final StringPath gender = _super.gender;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final NumberPath<Long> likes = _super.likes;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode1 = _super.likesCountByAttractionTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode2 = _super.likesCountByAttractionTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode3 = _super.likesCountByAttractionTypeCode3;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderMan = _super.likesCountByGenderMan;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode1 = _super.likesCountByGenderManAndAttractiveTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode2 = _super.likesCountByGenderManAndAttractiveTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode3 = _super.likesCountByGenderManAndAttractiveTypeCode3;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWoman = _super.likesCountByGenderWoman;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode1 = _super.likesCountByGenderWomanAndAttractiveTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode2 = _super.likesCountByGenderWomanAndAttractiveTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode3 = _super.likesCountByGenderWomanAndAttractiveTypeCode3;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final StringPath oauthId = createString("oauthId");
+
+    public final ListPath<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson> toLikeablePeople = this.<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson>createList("toLikeablePeople", com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson.class, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.class, PathInits.DIRECT2);
+
+    public final StringPath username = createString("username");
+
+    public QInstaMember(String variable) {
+        super(InstaMember.class, forVariable(variable));
+    }
+
+    public QInstaMember(Path<? extends InstaMember> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QInstaMember(PathMetadata metadata) {
+        super(InstaMember.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMemberBase.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMemberBase.java
@@ -1,0 +1,72 @@
+package com.ll.gramgram.boundedContext.instaMember.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QInstaMemberBase is a Querydsl query type for InstaMemberBase
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QInstaMemberBase extends EntityPathBase<InstaMemberBase> {
+
+    private static final long serialVersionUID = -574092751L;
+
+    public static final QInstaMemberBase instaMemberBase = new QInstaMemberBase("instaMemberBase");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final StringPath gender = createString("gender");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final NumberPath<Long> likes = createNumber("likes", Long.class);
+
+    public final NumberPath<Long> likesCountByAttractionTypeCode1 = createNumber("likesCountByAttractionTypeCode1", Long.class);
+
+    public final NumberPath<Long> likesCountByAttractionTypeCode2 = createNumber("likesCountByAttractionTypeCode2", Long.class);
+
+    public final NumberPath<Long> likesCountByAttractionTypeCode3 = createNumber("likesCountByAttractionTypeCode3", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderMan = createNumber("likesCountByGenderMan", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode1 = createNumber("likesCountByGenderManAndAttractiveTypeCode1", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode2 = createNumber("likesCountByGenderManAndAttractiveTypeCode2", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode3 = createNumber("likesCountByGenderManAndAttractiveTypeCode3", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderWoman = createNumber("likesCountByGenderWoman", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode1 = createNumber("likesCountByGenderWomanAndAttractiveTypeCode1", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode2 = createNumber("likesCountByGenderWomanAndAttractiveTypeCode2", Long.class);
+
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode3 = createNumber("likesCountByGenderWomanAndAttractiveTypeCode3", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public QInstaMemberBase(String variable) {
+        super(InstaMemberBase.class, forVariable(variable));
+    }
+
+    public QInstaMemberBase(Path<? extends InstaMemberBase> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QInstaMemberBase(PathMetadata metadata) {
+        super(InstaMemberBase.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMemberSnapshot.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMemberSnapshot.java
@@ -1,0 +1,103 @@
+package com.ll.gramgram.boundedContext.instaMember.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInstaMemberSnapshot is a Querydsl query type for InstaMemberSnapshot
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QInstaMemberSnapshot extends EntityPathBase<InstaMemberSnapshot> {
+
+    private static final long serialVersionUID = -1054594780L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QInstaMemberSnapshot instaMemberSnapshot = new QInstaMemberSnapshot("instaMemberSnapshot");
+
+    public final QInstaMemberBase _super = new QInstaMemberBase(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final StringPath eventTypeCode = createString("eventTypeCode");
+
+    //inherited
+    public final StringPath gender = _super.gender;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final QInstaMember instaMember;
+
+    //inherited
+    public final NumberPath<Long> likes = _super.likes;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode1 = _super.likesCountByAttractionTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode2 = _super.likesCountByAttractionTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByAttractionTypeCode3 = _super.likesCountByAttractionTypeCode3;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderMan = _super.likesCountByGenderMan;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode1 = _super.likesCountByGenderManAndAttractiveTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode2 = _super.likesCountByGenderManAndAttractiveTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderManAndAttractiveTypeCode3 = _super.likesCountByGenderManAndAttractiveTypeCode3;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWoman = _super.likesCountByGenderWoman;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode1 = _super.likesCountByGenderWomanAndAttractiveTypeCode1;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode2 = _super.likesCountByGenderWomanAndAttractiveTypeCode2;
+
+    //inherited
+    public final NumberPath<Long> likesCountByGenderWomanAndAttractiveTypeCode3 = _super.likesCountByGenderWomanAndAttractiveTypeCode3;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final StringPath username = createString("username");
+
+    public QInstaMemberSnapshot(String variable) {
+        this(InstaMemberSnapshot.class, forVariable(variable), INITS);
+    }
+
+    public QInstaMemberSnapshot(Path<? extends InstaMemberSnapshot> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QInstaMemberSnapshot(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QInstaMemberSnapshot(PathMetadata metadata, PathInits inits) {
+        this(InstaMemberSnapshot.class, metadata, inits);
+    }
+
+    public QInstaMemberSnapshot(Class<? extends InstaMemberSnapshot> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.instaMember = inits.isInitialized("instaMember") ? new QInstaMember(forProperty("instaMember")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/likeablePerson/entity/QLikeablePerson.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/likeablePerson/entity/QLikeablePerson.java
@@ -1,0 +1,71 @@
+package com.ll.gramgram.boundedContext.likeablePerson.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLikeablePerson is a Querydsl query type for LikeablePerson
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLikeablePerson extends EntityPathBase<LikeablePerson> {
+
+    private static final long serialVersionUID = 1545229958L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLikeablePerson likeablePerson = new QLikeablePerson("likeablePerson");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    public final NumberPath<Integer> attractiveTypeCode = createNumber("attractiveTypeCode", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember fromInstaMember;
+
+    public final StringPath fromInstaMemberUsername = createString("fromInstaMemberUsername");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final DateTimePath<java.time.LocalDateTime> modifyUnlockDate = createDateTime("modifyUnlockDate", java.time.LocalDateTime.class);
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember toInstaMember;
+
+    public final StringPath toInstaMemberUsername = createString("toInstaMemberUsername");
+
+    public QLikeablePerson(String variable) {
+        this(LikeablePerson.class, forVariable(variable), INITS);
+    }
+
+    public QLikeablePerson(Path<? extends LikeablePerson> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLikeablePerson(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLikeablePerson(PathMetadata metadata, PathInits inits) {
+        this(LikeablePerson.class, metadata, inits);
+    }
+
+    public QLikeablePerson(Class<? extends LikeablePerson> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromInstaMember = inits.isInitialized("fromInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("fromInstaMember")) : null;
+        this.toInstaMember = inits.isInitialized("toInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("toInstaMember")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/member/entity/QMember.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/member/entity/QMember.java
@@ -1,0 +1,61 @@
+package com.ll.gramgram.boundedContext.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1579367790L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMember member = new QMember("member1");
+
+    public final DateTimePath<java.time.LocalDateTime> createDate = createDateTime("createDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember instaMember;
+
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = createDateTime("modifyDate", java.time.LocalDateTime.class);
+
+    public final StringPath password = createString("password");
+
+    public final StringPath providerTypeCode = createString("providerTypeCode");
+
+    public final StringPath username = createString("username");
+
+    public QMember(String variable) {
+        this(Member.class, forVariable(variable), INITS);
+    }
+
+    public QMember(Path<? extends Member> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMember(PathMetadata metadata, PathInits inits) {
+        this(Member.class, metadata, inits);
+    }
+
+    public QMember(Class<? extends Member> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.instaMember = inits.isInitialized("instaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("instaMember")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/notification/entity/QNotification.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/notification/entity/QNotification.java
@@ -1,0 +1,75 @@
+package com.ll.gramgram.boundedContext.notification.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -298148144L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember fromInstaMember;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final NumberPath<Integer> newAttractiveTypeCode = createNumber("newAttractiveTypeCode", Integer.class);
+
+    public final StringPath newGender = createString("newGender");
+
+    public final NumberPath<Integer> oldAttractiveTypeCode = createNumber("oldAttractiveTypeCode", Integer.class);
+
+    public final StringPath oldGender = createString("oldGender");
+
+    public final DateTimePath<java.time.LocalDateTime> readDate = createDateTime("readDate", java.time.LocalDateTime.class);
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember toInstaMember;
+
+    public final StringPath typeCode = createString("typeCode");
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromInstaMember = inits.isInitialized("fromInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("fromInstaMember")) : null;
+        this.toInstaMember = inits.isInitialized("toInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("toInstaMember")) : null;
+    }
+
+}
+

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -57,6 +57,10 @@ public class NotProd {
                 instaMemberService.connect(memberUser3, "insta_user3", "W");
                 instaMemberService.connect(memberUser4, "insta_user4", "M");
                 instaMemberService.connect(memberUser5, "insta_user5", "W");
+                instaMemberService.connect(memberUser6ByKakao, "insta_user6", "M");
+                instaMemberService.connect(memberUser7ByGoogle, "insta_user7", "W");
+                instaMemberService.connect(memberUser8ByNaver, "insta_user8", "M");
+                instaMemberService.connect(memberUser9ByFacebook, "insta_user9", "W");
 
                 // 원활한 테스트와 개발을 위해서 자동으로 만들어지는 호감이 삭제, 수정이 가능하도록 쿨타임해제
                 LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
@@ -65,6 +69,14 @@ public class NotProd {
                 Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
                 LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+                LikeablePerson likeablePersonToInstaUser5 = likeablePersonService.like(memberUser2, "insta_user5", 2).getData();
+
+                LikeablePerson likeablePersonToInstaUser4_2 = likeablePersonService.like(memberUser2, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_3 = likeablePersonService.like(memberUser5, "insta_user4", 3).getData();
+                LikeablePerson likeablePersonToInstaUser4_4 = likeablePersonService.like(memberUser6ByKakao, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_5 = likeablePersonService.like(memberUser7ByGoogle, "insta_user4", 1).getData();
+                LikeablePerson likeablePersonToInstaUser4_6 = likeablePersonService.like(memberUser8ByNaver, "insta_user4", 2).getData();
+                LikeablePerson likeablePersonToInstaUser4_7 = likeablePersonService.like(memberUser9ByFacebook, "insta_user4", 3).getData();
             }
         };
     }

--- a/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.ll.gramgram.base.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -144,7 +144,7 @@ public class LikeablePersonController {
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode(instaMember, toListForm.gender, toListForm.attractiveTypeCode, toListForm.sortCode);
+            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember(instaMember, toListForm.gender, toListForm.attractiveTypeCode, toListForm.sortCode);
             model.addAttribute("likeablePeople", likeablePeople);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -128,19 +129,22 @@ public class LikeablePersonController {
         return rq.redirectWithMsg("/usr/likeablePerson/list", rsData);
     }
 
+    @Setter
+    public static class ToListForm {
+        private String gender = "";
+        private int attractiveTypeCode = 0;
+        private int sortCode = 1;
+    }
+
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model,
-                             @RequestParam(defaultValue = "") String gender,
-                             @RequestParam(defaultValue = "0") int attractiveTypeCode,
-                             @RequestParam(defaultValue = "1") int sortCode) {
+    public String showToList(Model model, ToListForm toListForm) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember(instaMember, gender, attractiveTypeCode, sortCode);
-
+            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode(instaMember, toListForm.gender, toListForm.attractiveTypeCode, toListForm.sortCode);
             model.addAttribute("likeablePeople", likeablePeople);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -130,7 +130,8 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model, String gender,
+    public String showToList(Model model,
+                             @RequestParam(defaultValue = "") String gender,
                              @RequestParam(defaultValue = "0") int attractiveTypeCode,
                              @RequestParam(defaultValue = "1") int sortCode) {
         InstaMember instaMember = rq.getMember().getInstaMember();
@@ -138,66 +139,7 @@ public class LikeablePersonController {
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            Stream<LikeablePerson> likeablePeopleStream = instaMember.getToLikeablePeople().stream();
-
-            if (gender != null && !gender.equals("")) { // 성별에 따라 필터링
-                likeablePeopleStream = likeablePeopleStream.filter(
-                        e -> Objects.equals(e.getFromInstaMember().getGender(), gender
-                ));
-            }
-
-            if (attractiveTypeCode != 0) { // 호감사유에 따라 필터링
-                likeablePeopleStream = likeablePeopleStream.filter(
-                        e -> e.getAttractiveTypeCode() == attractiveTypeCode
-                );
-            }
-
-            switch (sortCode) {
-                case 1:
-                    // 최신 순 정렬
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            (lp2, lp1) -> lp1.getCreateDate().compareTo(lp2.getCreateDate())
-                    );
-                    break;
-                case 2:
-                    // 날짜 순 정렬(오래 전에 받은 호감표시를 우선적으로 표시)
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            (lp2, lp1) -> lp1.getCreateDate().compareTo(lp2.getCreateDate()) * -1
-                    );
-                    break;
-                case 3:
-                    // 인기 많은 순 정렬(인기가 많은 사람의 호감표시를 우선적으로 표시)
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            (lp2, lp1) -> lp1.getFromInstaMember().getToLikeablePeople().size() - lp2.getFromInstaMember().getToLikeablePeople().size()
-                    );
-                    break;
-                case 4:
-                    // 인기 적은 순 정렬
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            (lp2, lp1) -> (lp1.getFromInstaMember().getToLikeablePeople().size() - lp2.getFromInstaMember().getToLikeablePeople().size()) * -1
-                    );
-                    break;
-                case 5:
-                    // 성별에 따른 정렬(여성에게 받은 호감표시를 먼저), 2순위 정렬 조건은 최신순
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            (lp2, lp1) -> {
-                                if (lp2.getFromInstaMember().getGender().equals(lp1.getFromInstaMember().getGender())){
-                                    return lp1.getCreateDate().compareTo(lp2.getCreateDate());
-                                }
-                                return lp1.getFromInstaMember().getGender().compareTo(lp2.getFromInstaMember().getGender());
-                            }
-                    );
-                    break;
-                case 6:
-                    // 호감사유에 따른 정렬(외모, 성격, 능력 순), 2순위 정렬 조건은 최신순
-                    likeablePeopleStream = likeablePeopleStream.sorted(
-                            Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
-                                    .thenComparing((lp2, lp1) -> lp1.getCreateDate().compareTo(lp2.getCreateDate()))
-                    );
-                    break;
-            }
-
-            List<LikeablePerson> likeablePeople = likeablePeopleStream.collect(Collectors.toList());
+            List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember(instaMember, gender, attractiveTypeCode, sortCode);
 
             model.addAttribute("likeablePeople", likeablePeople);
         }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long>, LikeablePersonRepositoryCustom {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 
     List<LikeablePerson> findByFromInstaMember_username(String username);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
 
-    List<LikeablePerson> findQslByToInstaMemberAndGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode);
+    List<LikeablePerson> findQslByToInstaMember(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeablePersonRepositoryCustom {
+    Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
+
+    List<LikeablePerson> findQslByToInstaMemberAndGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode);
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -38,7 +38,7 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
     }
 
     @Override
-    public List<LikeablePerson> findQslByToInstaMemberAndGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
+    public List<LikeablePerson> findQslByToInstaMember(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
 
         Sort sort = switch (sortCode) {
             case 2 -> Sort.by("id").ascending();

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,0 +1,106 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
+
+@RequiredArgsConstructor
+public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(likeablePerson)
+                        .where(
+                                likeablePerson.fromInstaMember.id.eq(fromInstaMemberId)
+                                        .and(
+                                                likeablePerson.toInstaMember.username.eq(toInstaMemberUsername)
+                                        )
+                        )
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public List<LikeablePerson> findQslByToInstaMemberAndGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
+
+        Sort sort = switch (sortCode) {
+            case 2 -> Sort.by("id").ascending();
+            case 3 -> Sort.by("likes").descending().and(Sort.by("id").descending());
+            case 4 -> Sort.by("likes").ascending().and(Sort.by("id").descending());
+            case 5 -> Sort.by("gender").descending().and(Sort.by("id").descending());
+            case 6 -> Sort.by("attractiveTypeCode").ascending().and(Sort.by("id").descending());
+            default -> Sort.by("id").descending();
+        };
+
+        JPAQuery<LikeablePerson> contentQuery = jpaQueryFactory
+                .select(likeablePerson)
+                .from(likeablePerson)
+                .where(
+                        likeablePerson.toInstaMember.eq(instaMember),
+                        eqGender(gender),
+                        eqAttractiveTypeCode(attractiveTypeCode)
+                )
+                .orderBy(getOrderSpecifiers(sort));
+
+        return contentQuery.fetch();
+    }
+
+    private static BooleanExpression eqAttractiveTypeCode(int attractiveTypeCode) {
+        if (attractiveTypeCode <= 0) return null;
+
+        return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
+    }
+
+    private static BooleanExpression eqGender(String gender) {
+        if (gender == null || gender.isBlank()) return null;
+
+        return likeablePerson.fromInstaMember.gender.eq(gender);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(@NonNull Sort sort) {
+        return sort.stream()
+                .map(this::getOrderSpecifier)
+                .distinct()
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(Sort.Order sortOrder) {
+        Order order = sortOrder.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+        Expression<?> expression = switch (sortOrder.getProperty()) {
+            case "likes" -> likesExpression();
+            case "createDate" -> likeablePerson.createDate;
+            case "gender" -> likeablePerson.fromInstaMember.gender;
+            case "attractiveTypeCode" -> likeablePerson.attractiveTypeCode;
+            default -> likeablePerson.id;
+        };
+
+        return new OrderSpecifier(order, expression);
+    }
+
+    private NumberExpression<Long> likesExpression() {
+        return likeablePerson.fromInstaMember.likesCountByGenderWomanAndAttractiveTypeCode1
+                .add(likeablePerson.fromInstaMember.likesCountByGenderWomanAndAttractiveTypeCode2)
+                .add(likeablePerson.fromInstaMember.likesCountByGenderWomanAndAttractiveTypeCode3)
+                .add(likeablePerson.fromInstaMember.likesCountByGenderManAndAttractiveTypeCode1)
+                .add(likeablePerson.fromInstaMember.likesCountByGenderManAndAttractiveTypeCode2)
+                .add(likeablePerson.fromInstaMember.likesCountByGenderManAndAttractiveTypeCode3);
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -12,6 +12,7 @@ import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRe
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -227,11 +228,11 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감표시 사유 수정이 가능합니다.");
     }
 
-    public List<LikeablePerson> findByToInstaMemberAndGenderAndAttractiveTypeCode(String username, String gender, int attractiveTypeCode, int sortCode) {
-        return findByToInstaMemberAndGenderAndAttractiveTypeCode(instaMemberService.findByUsername(username).get(), gender, attractiveTypeCode, sortCode);
+    public List<LikeablePerson> findByToInstaMember(String username, @Nullable String gender, int attractiveTypeCode, int sortCode) {
+        return findByToInstaMember(instaMemberService.findByUsername(username).get(), gender, attractiveTypeCode, sortCode);
     }
 
-    public List<LikeablePerson> findByToInstaMemberAndGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
-        return likeablePersonRepository.findQslByToInstaMemberAndGenderAndAttractiveTypeCode(instaMember, gender, attractiveTypeCode, sortCode);
+    public List<LikeablePerson> findByToInstaMember(InstaMember instaMember, @Nullable String gender, int attractiveTypeCode, int sortCode) {
+        return likeablePersonRepository.findQslByToInstaMember(instaMember, gender, attractiveTypeCode, sortCode);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -15,9 +15,12 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -225,5 +228,56 @@ public class LikeablePersonService {
         }
 
         return RsData.of("S-1", "호감표시 사유 수정이 가능합니다.");
+    }
+
+    public List<LikeablePerson> findByToInstaMember(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
+        Stream<LikeablePerson> likeablePeopleStream = instaMember.getToLikeablePeople().stream();
+
+        if (!gender.isEmpty()) { // 성별에 따라 필터링
+            likeablePeopleStream = likeablePeopleStream.filter(
+                    e -> Objects.equals(e.getFromInstaMember().getGender(), gender
+                    ));
+        }
+
+        if (attractiveTypeCode != 0) { // 호감사유에 따라 필터링
+            likeablePeopleStream = likeablePeopleStream.filter(
+                    e -> e.getAttractiveTypeCode() == attractiveTypeCode
+            );
+        }
+
+        likeablePeopleStream = switch (sortCode) {
+            case 2 ->
+                // 날짜 순 정렬(오래 전에 받은 호감표시를 우선적으로 표시)
+                    likeablePeopleStream.sorted(
+                            Comparator.comparing(LikeablePerson::getId)
+                    );
+            case 3 ->
+                // 인기 많은 순 정렬(인기가 많은 사람의 호감표시를 우선적으로 표시)
+                    likeablePeopleStream.sorted(
+                                    Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes()).reversed()
+                                            .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                    );
+            case 4 ->
+                // 인기 적은 순 정렬
+                    likeablePeopleStream.sorted(
+                            Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes())
+                                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                    );
+            case 5 ->
+                // 성별에 따른 정렬(여성에게 받은 호감표시를 먼저), 2순위 정렬 조건은 최신순
+                    likeablePeopleStream.sorted(
+                            Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getGender()).reversed()
+                                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                    );
+            case 6 ->
+                // 호감사유에 따른 정렬(외모, 성격, 능력 순), 2순위 정렬 조건은 최신순
+                    likeablePeopleStream.sorted(
+                            Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
+                                    .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                    );
+            default -> likeablePeopleStream;
+        };
+
+        return likeablePeopleStream.toList();
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -230,6 +230,10 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감표시 사유 수정이 가능합니다.");
     }
 
+    public List<LikeablePerson> findByToInstaMember(String username, String gender, int attractiveTypeCode, int sortCode) {
+        return findByToInstaMember(instaMemberService.findByUsername(username).get(), gender, attractiveTypeCode, sortCode);
+    }
+
     public List<LikeablePerson> findByToInstaMember(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
         Stream<LikeablePerson> likeablePeopleStream = instaMember.getToLikeablePeople().stream();
 

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -219,7 +219,7 @@ public class LikeablePersonServiceTests {
     @Test
     @DisplayName("정렬 - 최신순")
     void t009() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 1);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 1);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
@@ -229,7 +229,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 날짜순")
     @Rollback(false)
     void t010() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 2);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 2);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
@@ -239,7 +239,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 인기 많은 순")
     @Rollback(false)
     void t011() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 3);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 3);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -252,7 +252,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 인기 적은 순")
     @Rollback(false)
     void t012() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 4);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 4);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -265,7 +265,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 성별순")
     @Rollback(false)
     void t013() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 5);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 5);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -278,7 +278,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 호감사유순")
     @Rollback(false)
     void t014() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 6);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 6);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -212,5 +214,76 @@ public class LikeablePersonServiceTests {
         assertThat(
                 likeablePersonToBts.getModifyUnlockDate().isAfter(coolTime)
         ).isTrue();
+    }
+
+    @Test
+    @DisplayName("정렬 - 최신순")
+    void t009() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 1);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
+    }
+
+    @Test
+    @DisplayName("정렬 - 날짜순")
+    @Rollback(false)
+    void t010() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 2);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
+    }
+
+    @Test
+    @DisplayName("정렬 - 인기 많은 순")
+    @Rollback(false)
+    void t011() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 3);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes()).reversed()
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 인기 적은 순")
+    @Rollback(false)
+    void t012() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 4);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getLikes())
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 성별순")
+    @Rollback(false)
+    void t013() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 5);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing((LikeablePerson lp) -> lp.getFromInstaMember().getGender()).reversed()
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
+    }
+
+    @Test
+    @DisplayName("정렬 - 호감사유순")
+    @Rollback(false)
+    void t014() {
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 6);
+
+        assertThat(likeablePeople)
+                .isSortedAccordingTo(
+                        Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
+                                .thenComparing(Comparator.comparing(LikeablePerson::getId).reversed())
+                );
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -219,7 +219,7 @@ public class LikeablePersonServiceTests {
     @Test
     @DisplayName("정렬 - 최신순")
     void t009() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 1);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 1);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
@@ -229,7 +229,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 날짜순")
     @Rollback(false)
     void t010() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 2);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 2);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
@@ -239,7 +239,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 인기 많은 순")
     @Rollback(false)
     void t011() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 3);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 3);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -252,7 +252,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 인기 적은 순")
     @Rollback(false)
     void t012() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 4);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 4);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -265,7 +265,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 성별순")
     @Rollback(false)
     void t013() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 5);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 5);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(
@@ -278,7 +278,7 @@ public class LikeablePersonServiceTests {
     @DisplayName("정렬 - 호감사유순")
     @Rollback(false)
     void t014() {
-        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMemberAndGenderAndAttractiveTypeCode("insta_user4", "", 0, 6);
+        List<LikeablePerson> likeablePeople = likeablePersonService.findByToInstaMember("insta_user4", "", 0, 6);
 
         assertThat(likeablePeople)
                 .isSortedAccordingTo(


### PR DESCRIPTION
# 할일

- [x] 내가 받은 호감 리스트
    - [x] 성별 필터링
    - [x] 호감사유 필터링
        - [x] 원활한 테스트를 위해서 인스타 사용자 user4 가 다수의 호감표시를 받도록 NotProd 변경
        - [x] NotProd 변경에 따른 테스트케이스 수정
    - [x] 정렬
        - [x] 최신순
            - 애초에 최신순으로 정렬되어 있었음
            - 그래서 딱히 할게 없음
        - [x] 날짜순
            - id DESC
        - [x] 인기많은순
            - likeCount DESC, id DESC
            - 이 작업을 위해 NotProd 에서 호감표시건을 더 만듬
        - [x] 인기적은순
            - likeCount ASC, id DESC
        - [x] 성별순
            - gender DESC, id DESC
        - [x] 호감사유순
            - gender ASC, id DESC
        - [x] 테스트케이스
- [x] 알림
    - [x] 호감표시할 때 알림생성
    - [x] 호감사유변경할 때 알림생성
    - [x] 알림목록
    - [x] 알림목록 확인 시 마다, 아직 readDate 가 null 인것들만 추려서 날짜갱신
    - [x] 상단바에 아직 읽지 않은 알림이 존재하는지 인디케이터로 표시
- [ ] 호감에 대한 수정/삭제 쿨타임
    - [x] 설정정보 가져오기
    - [x] 호감표시/호감사유변경 시에 modifyUnlockDate 갱신(현재날짜 + 쿨타임)
    - [x] UI에서 쿨타임 안차면 수정/삭제 못 하도록
    - [x] UI에서 남은시간 표시
    - [x] LikeablePersonService::canCancel 에 쿨타임 체크 추가
    - [x] LikeablePersonService::canModifyLike 에 쿨타임 체크 추가
    - [x] TC : 호감사유를 변경하면 쿨타임이 갱신된다. 실패, 해결
- [x] 회원가입 폼
    - [x] 로그인 상태에서 들어올 수 없다.
    - [x] 폼이 있어야 한다.
    - [x] input[name="username"] 필드가 있어야 한다.
    - [x] input[name="password"] 필드가 있어야 한다.
    - [x] 폼 체크
- [x] 회원가입 폼 처리
    - [x] 로그인 상태에서 들어올 수 없다.
    - [x] 유효성 체크를 해야 한다.
    - [x] member 테이블에 회원이 저장되어야 한다.
    - [x] 처리 후에 / 로 이동해야 한다. 302
    - [x] 회원가입이 완료되었습니다. /usr/member/login 으로 302
- [x] 로그인 폼
    - [x] 로그인 상태에서 들어올 수 없다.
    - [x] 폼이 있어야 한다.
    - [x] input[name="username"] 필드가 있어야 한다.
    - [x] input[name="password"] 필드가 있어야 한다.
    - [x] 폼 체크
- [x] 로그인 폼 처리(스프링 시큐리티가 알아서 해줌)
    - [x] 세션에 데이터가 들어있는지 확인
- [x] 레이아웃 네비바 구현
    - [x] 로그인 버튼
    - [x] 회원가입 버튼
    - [x] 로그아웃 버튼
- [x] 로그인 후에는 내비바에 로그인된 회원의 username 이 보여야 한다.
- [x] 정적파일 정리
    - [x] 두루두루 사용되는 CSS 를 common.css 로 모으기
    - [x] 두루두루 사용되는 JS 를 common.js 로 모으기
- [x] toastMsg 에 ttl 기능 추가
- [x] 인스타그램 회원정보 입력
    - [x] 입력한 인스타그램 ID가 이미 존재하더라도, 그것의 성별이 아직 U 이면 연결가능
    - [x] 로그인한 사람만 가능
    - [x] 아이디
    - [x] 성별
- [x] 인스타그램 회원정보 입력 폼 처리
    - [x] 로그인한 사람만 가능
    - [x] 아이디
    - [x] 성별
    - [x] 회원과 인스타회원의 연결
    - [x] 성공했을 때 호감표시 페이지로 이동
- [x] 본인이 좋아하는 사람 등록 폼
    - [x] 본인의 인스타그램 회원정보 입력을 완료한 사람만 가능
    - [x] 인스타그램 아이디
    - [x] 매력포인트(외모, 성격, 능력)
- [x] 본인이 좋아하는 사람 등록 폼 처리
    - [x] 아직 우리 서비스에 등록되지 않은 인스타 유저에게도 호감표시 가능
- [x] 엔티티 클래스의 중복로직 제거